### PR TITLE
Don't match against binary and number in guard

### DIFF
--- a/lib/simple_repo/query.ex
+++ b/lib/simple_repo/query.ex
@@ -63,12 +63,12 @@ defmodule SimpleRepo.Query do
   defp scope_query(queriable, {key, nil}) do
     from m in queriable, where: is_nil(field(m, ^key))
   end
-  defp scope_query(queriable, {key, value})
-       when is_binary(value) or is_number(value) do
-    queriable |> where(^[{key, value}])
-  end
   defp scope_query(queriable, {key, value}) when is_atom(value) do
     scope_query(queriable, {key, Atom.to_string(value)})
+  end
+  defp scope_query(queriable, {key, value})
+       when not is_list(value) and not is_tuple(value) do
+    queriable |> where(^[{key, value}])
   end
   defp scope_query(queriable, {key, values}) when is_list(values) do
     queriable |> where([m], field(m, ^key) in ^values)
@@ -77,7 +77,7 @@ defmodule SimpleRepo.Query do
     from m in queriable, where: not is_nil(field(m, ^key))
   end
   defp scope_query(queriable, {key, {:not, value}})
-       when is_binary(value) or is_number(value) do
+       when not is_list(value) and not is_tuple(value) do
     scope_query(queriable, {key, {:not, [value]}})
   end
   defp scope_query(queriable, {key, {:not, values}}) when is_list(values) do

--- a/test/simple_repo/query_test.exs
+++ b/test/simple_repo/query_test.exs
@@ -75,6 +75,24 @@ defmodule SimpleRepo.QueryTest do
       end
     end
 
+    test "scopes to specific NaiveDateTime element" do
+      test_struct = TestStruct |> Repo.all() |> Enum.random()
+      query_result = TestStruct
+      |> Query.scoped([inserted_at: test_struct.inserted_at])
+      |> Repo.all()
+
+      assert length(query_result) > 0
+
+      assert Enum.all?(
+        query_result,
+        fn item ->
+          NaiveDateTime.compare(
+            test_struct.inserted_at, item.inserted_at
+          ) == :eq
+        end
+      )
+    end
+
     test "scopes to items not equal to value", %{structs: structs} do
       results1 = Query.scoped(TestStruct, [type: {:not, "foo"}]) |> Repo.all
       assert length(results1) == 4
@@ -103,6 +121,24 @@ defmodule SimpleRepo.QueryTest do
       for expected <- struct_data2 do
         assert Enum.member?(result_data2, expected)
       end
+    end
+
+    test "scopes to valie different to a specific NaiveDateTime" do
+      test_struct = TestStruct |> Repo.all() |> Enum.random()
+      query_result = TestStruct
+      |> Query.scoped([inserted_at: {:not, test_struct.inserted_at}])
+      |> Repo.all()
+
+      assert length(query_result) > 0
+
+      assert Enum.all?(
+        query_result,
+        fn item ->
+          NaiveDateTime.compare(
+            test_struct.inserted_at, item.inserted_at
+          ) != :eq
+        end
+      )
     end
 
     test "scopes to items equal to float value", %{structs: structs} do


### PR DESCRIPTION
- just exclude list and tuple for standard value queries to enable different time structs